### PR TITLE
fix: use real email from Azure AD instead of navIdent for subscriptions

### DIFF
--- a/src/components/StatusPage/SubscriptionModal.tsx
+++ b/src/components/StatusPage/SubscriptionModal.tsx
@@ -28,7 +28,7 @@ const SubscriptionModal = ({ isOpen, onClose, services, user }: SubscriptionModa
     // For internal users, skip to preferences step with their email
     useEffect(() => {
         if (isInternalUser && isOpen) {
-            setEmail(user?.navIdent + "@nav.no")
+            setEmail(user?.email || user?.navIdent + "@nav.no")
             setStep('preferences')
             setSelectedServices(services.map(s => s.id || ''))
         }

--- a/src/pages/api/userInfo.ts
+++ b/src/pages/api/userInfo.ts
@@ -15,6 +15,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         let userInfo = {
             name: "LOKAL, BRUKER",
             navIdent: "J162994",
+            email: "jonas.juvet@nav.no",
             adminAccess: true
         }
         res.status(200).json(userInfo);
@@ -45,6 +46,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     let userInfo = {
                        name: claims.name,
                        navIdent: claims.NAVident,
+                       email: claims.preferred_username,
                        adminAccess: usersWithAccess.includes(String(claims.NAVident))
                    }
                    

--- a/src/types/userData.ts
+++ b/src/types/userData.ts
@@ -1,5 +1,6 @@
 export interface UserData {
     name: string
     navIdent: string
+    email?: string
     adminAccess: boolean
 }


### PR DESCRIPTION
## Summary
- Internal users subscribing to notifications got `navIdent@nav.no` (e.g. `J162994@nav.no`) instead of their actual email
- Now reads `preferred_username` claim from Azure AD JWT token which contains the real email (e.g. `jonas.juvet@nav.no`)
- Falls back to `navIdent@nav.no` if email claim is missing

## Test plan
- [ ] Logg inn lokalt og sjekk at SubscriptionModal viser riktig e-post
- [ ] Verifiser at `preferred_username` claim finnes i Azure AD-tokenet i dev/prod
- [ ] Test at abonnement opprettes med riktig e-postadresse