### PR TITLE
chore: bruk Chainguard sikre base images i Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-# Base on official Node.js Alpine image
-FROM node:18-alpine 
-# AS builder
+# --- Build stage ---
+# Use the -dev variant: it includes a shell, npm and apk (the slim variant has
+# none of these, so the npm steps below would fail there).
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22-dev AS builder
 
-# Set working directory
 WORKDIR /usr/src/app
 
-# Copy package.json and package-lock.json to utilize Docker cache
-COPY package*.json ./
+# Copy package.json and package-lock.json to utilize Docker cache.
+# --chown lets the nonroot user write package-lock.json during npm install.
+COPY --chown=node:node package*.json ./
 
 RUN --mount=type=secret,id=NODE_AUTH_TOKEN sh -c \
     'npm config set //npm.pkg.github.com/:_authToken=$(cat /run/secrets/NODE_AUTH_TOKEN)'
@@ -14,30 +15,37 @@ RUN npm config set @navikt:registry=https://npm.pkg.github.com
 
 RUN npm install
 
-# Copy the remaining files for the build process
-COPY babel.config.json babel.config.json
-COPY tsconfig.json tsconfig.json
-COPY next-env.d.ts next-env.d.ts
-COPY src/ src/
-COPY public/ public/
-COPY next.config.js next.config.js
+# Copy the remaining files for the build process (owned by the nonroot user
+# so next build can write into the working directory).
+COPY --chown=node:node babel.config.json babel.config.json
+COPY --chown=node:node tsconfig.json tsconfig.json
+COPY --chown=node:node next-env.d.ts next-env.d.ts
+COPY --chown=node:node src/ src/
+COPY --chown=node:node public/ public/
+COPY --chown=node:node next.config.js next.config.js
 
 # Build the app
 RUN npm run build
 
-# --- Runtime image ---
-#FROM node:18-alpine
+# --- Runtime stage ---
+# Use the standard variant (not -slim): "npm start" (next start) needs npm,
+# which the slim variant omits.
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22
 
-# Set working directory
-# WORKDIR /usr/src/app
+WORKDIR /usr/src/app
+
+ENV NODE_ENV=production
 
 # Copy the build output and required files from the builder stage
-# COPY --from=builder /usr/src/app/.next/ .next/
-# COPY --from=builder /usr/src/app/node_modules/ node_modules/
-# COPY --from=builder /usr/src/app/package*.json ./
+COPY --from=builder /usr/src/app/.next/ .next/
+COPY --from=builder /usr/src/app/node_modules/ node_modules/
+COPY --from=builder /usr/src/app/public/ public/
+COPY --from=builder /usr/src/app/package.json package.json
+COPY --from=builder /usr/src/app/next.config.js next.config.js
 
 # Expose the listening port
 EXPOSE 3000
 
-# Start the app
-CMD ["npm", "start"]
+# The Chainguard node image sets ENTRYPOINT to /usr/bin/node, so override it
+# to run "npm start" (next start) instead of treating args as a script path.
+ENTRYPOINT ["npm", "start"]


### PR DESCRIPTION
## Hva

Migrerer frontend til NAVs Chainguard pull-through registry, og gjør Dockerfile om til en ekte **multi-stage build** (den var single-stage med byggeverktøy i runtime).

- **build:** `node:22-dev` (har shell + npm)
- **runtime:** `node:22` (slankt — `next start` trenger npm, så ikke `-slim`)
- Bumpet Node **18 (EOL) → 22**

## Tilpasninger for Chainguard

- `COPY --chown=node:node` så non-root kan skrive `package-lock.json` og `.next/` under build (ellers `EACCES`)
- `ENTRYPOINT` i stedet for `CMD` (base image har fast `/usr/bin/node`, så `CMD ["npm","start"]` ble kjørt som `node npm start`)

## Testet

- ✅ `docker build` går grønt (npm install + next build)
- ✅ Container starter: `next start` kjører og svarer **HTTP 200** på `:3000`

> ℹ️ `NODE_AUTH_TOKEN` leveres som vanlig via `nais/docker-build-push` i CI.